### PR TITLE
Update validators.py

### DIFF
--- a/abstract/validators.py
+++ b/abstract/validators.py
@@ -4,6 +4,8 @@ from functools import partial
 from django.core.exceptions import ValidationError
 
 
+# Unintended feature: this splits words at apostrophes and slashes inflating the word count.
+# A quick fix below is to include small margins in the string length validation.
 words_re = re.compile(r"\w+(?:-\w+)+|\w+|\d+")
 
 
@@ -14,7 +16,13 @@ def validate_n_word_or_less(value, n):
             "This field is limited to {} words or less.".format(n))
 
 
-validate_30_words_or_less = partial(validate_n_word_or_less, **{'n': 30})
-validate_100_words_or_less = partial(validate_n_word_or_less, **{'n': 100})
-validate_200_words_or_less = partial(validate_n_word_or_less, **{'n': 200})
-validate_250_words_or_less = partial(validate_n_word_or_less, **{'n': 250})
+#validate_30_words_or_less = partial(validate_n_word_or_less, **{'n': 30})
+#validate_100_words_or_less = partial(validate_n_word_or_less, **{'n': 100})
+#validate_200_words_or_less = partial(validate_n_word_or_less, **{'n': 200})
+#validate_250_words_or_less = partial(validate_n_word_or_less, **{'n': 250})
+
+# Updated word length threshholds with margins
+validate_30_words_or_less = partial(validate_n_word_or_less, **{'n': 35})
+validate_100_words_or_less = partial(validate_n_word_or_less, **{'n': 130})
+validate_200_words_or_less = partial(validate_n_word_or_less, **{'n': 220})
+validate_250_words_or_less = partial(validate_n_word_or_less, **{'n': 300})


### PR DESCRIPTION
The code splits on characters including slashes and apostrophes, so URLs and possessive nouns inflate the word count. Gracefully handling slightly over long word lengths would be better behaviour. Note the website text suggesting max 250 words for abstract etc should stay the same.